### PR TITLE
Subpage filter generator

### DIFF
--- a/pywikibot/page.py
+++ b/pywikibot/page.py
@@ -176,6 +176,11 @@ class BasePage(UnicodeMixin, ComparableMixin):
         return self._link.namespace
 
     @property
+    def namespace_obj(self):
+        """Return the namespace object of the page."""
+        return self.site.namespaces[self.namespace()]
+
+    @property
     def content_model(self):
         """Return the content model for this page.
 
@@ -186,6 +191,20 @@ class BasePage(UnicodeMixin, ComparableMixin):
         if not hasattr(self, '_contentmodel'):
             self.site.loadpageinfo(self)
         return self._contentmodel
+
+    @property
+    def depth(self):
+        """Return the depth/subpage level of the page."""
+        if not hasattr(self, '_depth'):
+            # Check if the namespace allows subpages
+            if self.namespace_obj.subpages:
+                # Count how many '/'s we have in the title
+                _depth = len(list(re.finditer('/', self.title())))
+            else:
+                # Does not allow subpages, which means depth is always 0
+                _depth = 0
+
+        return _depth
 
     @deprecated_args(decode=None, savetitle="asUrl")
     def title(self, underscore=False, withNamespace=True,

--- a/scripts/interwiki.py
+++ b/scripts/interwiki.py
@@ -2466,7 +2466,7 @@ def page_empty_check(page):
     @rtype: bool
     """
     # Check if the page is in content namespace
-    if page.namespace() == 0:
+    if page.namespace_obj.content:
         # Check if the page contains at least 50 characters
         return len(page.text) < 50
     else:

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -516,6 +516,18 @@ class TestPageObject(DefaultSiteTestCase):
         page_copy.isDisambig()
         self.assertTrue(page_copy.isRedirectPage())
 
+    def test_depth(self):
+        """Test page depth calculation."""
+        site = self.get_site()
+        page_d0 = pywikibot.Page(site, '/home/test/')
+        self.assertEqual(page_d0.depth, 0)
+
+        page_user_d0 = pywikibot.Page(site, 'User:Sn1per')
+        self.assertEqual(page_user_d0.depth, 0)
+
+        page_d3 = pywikibot.Page(site, 'User:Sn1per/ProtectTest1/test/test')
+        self.assertEqual(page_d3.depth, 3)
+
 
 class TestPageDeprecation(DefaultSiteTestCase, DeprecationTestCase):
 

--- a/tests/pagegenerators_tests.py
+++ b/tests/pagegenerators_tests.py
@@ -22,6 +22,7 @@ from pywikibot import pagegenerators, date
 from pywikibot.pagegenerators import (
     PagesFromTitlesGenerator,
     PreloadingGenerator,
+    CategorizedPageGenerator
 )
 
 from tests import join_data_path
@@ -231,6 +232,33 @@ class EdittimeFilterPageGeneratorTestCase(TestCase):
         gen = pagegenerators.EdittimeFilterPageGenerator(
             gen, last_edit_start=nine_days_ago)
         self.assertEqual(len(list(gen)), 0)
+
+
+class SubpageFilterGeneratorTestCase(TestCase):
+
+    """Test SubpageFilterGenerator."""
+
+    family = 'test'
+    code = 'test'
+
+    def test_subpage_filter(self):
+        site = self.get_site()
+        test_cat = pywikibot.Category(site, 'Subpage testing')
+
+        gen = CategorizedPageGenerator(test_cat)
+        gen = pagegenerators.SubpageFilterGenerator(gen, 0)
+        expect_0 = ('/home/test',)
+        self.assertPagelistTitles(gen, titles=expect_0, site=site)
+
+        gen = CategorizedPageGenerator(test_cat)
+        gen = pagegenerators.SubpageFilterGenerator(gen, 3)
+        expect_3 = (
+            '/home/test',
+            'User:Sn1per/ProtectTest1/test',
+            'User:Sn1per/ProtectTest1/test/test',
+            'User:Sn1per/sandbox',
+        )
+        self.assertPagelistTitles(gen, titles=expect_3, site=site)
 
 
 class TestRepeatingGenerator(RecentChangesTestCase):

--- a/tests/site_tests.py
+++ b/tests/site_tests.py
@@ -2015,6 +2015,14 @@ class TestSiteInfo(DefaultSiteTestCase):
         self.assertRegex(mysite.siteinfo['timezone'], "([A-Z]{3,4}|[A-Z][a-z]+/[A-Z][a-z]+)")
         self.assertIn(mysite.siteinfo['case'], ["first-letter", "case-sensitive"])
 
+    def test_siteinfo_boolean(self):
+        """Test conversion of boolean properties from empty strings to True/False."""
+        mysite = self.get_site()
+        self.assertIn(mysite.siteinfo['titleconversion'], [True, False])
+
+        self.assertIn(mysite.namespaces[0].subpages, [True, False])
+        self.assertIn(mysite.namespaces[0].content, [True, False])
+
     def test_siteinfo_v1_16(self):
         """Test v.16+ siteinfo values."""
         if MediaWikiVersion(self.site.version()) < MediaWikiVersion('1.16'):


### PR DESCRIPTION
* Filter that excludes subpages that have a high depth
  i.e. how many parents
* Siteinfo converts boolean properties (that we use) into actual
  boolean values
* Page.depth returns the subpage depth
* Page.namespace_obj returns the Namespace object, rather than
  the int Namespace id
* Update interwiki script to use 'content' property of Namespace
  (which is now a boolean) for page_empty_check()
* Unit tests for above

Bug: T121323
Change-Id: Ia53580cf8ad7387c14d6ca3bf4fcf5b35f53edd4